### PR TITLE
Added Map.prototype.keys() polyfill to support IE11.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,16 @@ var Multimap = (function() {
   var mapCtor;
   if (typeof Map !== 'undefined') {
     mapCtor = Map;
+
+    if (!Map.prototype.keys) {
+      Map.prototype.keys = function() {
+        var keys = [];
+        this.forEach(function(item, key) {
+          keys.push(key);
+        });
+        return keys;
+      };
+    }
   }
 
   function Multimap(iterable) {


### PR DESCRIPTION
Internet Explorer tests were not passing due to missing Map.prototype.keys().  All tests from tests/test.html now passing.