### PR TITLE
`makeIterator()` return an `iterable` object

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,6 +200,9 @@ var Multimap = (function() {
       var nextIndex = 0;
 
       return {
+        [Symbol.iterator](){
+          return this
+        },
         next: function(){
           return nextIndex < iterator.length ?
             {value: iterator[nextIndex++], done: false} :


### PR DESCRIPTION
This fixes #12 and allow to use `for..of` and array spread.